### PR TITLE
Fix version constraints + minor adjustments for prettier 3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
                 "node": ">=20"
             },
             "peerDependencies": {
-                "prettier": ">=3.0.0 <3.6.0"
+                "prettier": ">=3.0.0 <3.7.0"
             }
         },
         "node_modules/@augment-vir/assert": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "virmator": "^14.3.1"
     },
     "peerDependencies": {
-        "prettier": ">=3.0.0 <3.6.0"
+        "prettier": ">=3.0.0 <3.7.0"
     },
     "engines": {
         "node": ">=20"

--- a/src/preprocessing.ts
+++ b/src/preprocessing.ts
@@ -30,7 +30,10 @@ function addMultilinePrinter(options: ActualParserOptions): void {
         const plugins = options.plugins ?? [];
         const firstMatchedPlugin = plugins.find(
             (plugin): plugin is Plugin =>
-                typeof plugin !== 'string' && !!plugin.printers && !!plugin.printers[astFormat],
+                typeof plugin !== 'string' &&
+                !(plugin instanceof URL) &&
+                !!plugin.printers &&
+                !!plugin.printers[astFormat],
         );
         if (!firstMatchedPlugin || typeof firstMatchedPlugin === 'string') {
             throw new Error(`Matched invalid first plugin: ${firstMatchedPlugin}`);
@@ -56,10 +59,11 @@ function addMultilinePrinter(options: ActualParserOptions): void {
     }
 }
 
-function findPluginsByParserName(parserName: string, plugins: (Plugin | string)[]): Plugin[] {
+function findPluginsByParserName(parserName: string, plugins: (Plugin | URL | string)[]): Plugin[] {
     return plugins.filter((plugin): plugin is Plugin => {
         return (
             typeof plugin === 'object' &&
+            !(plugin instanceof URL) &&
             (plugin as {pluginMarker: any}).pluginMarker !== pluginMarker &&
             !!plugin.parsers?.[parserName]
         );


### PR DESCRIPTION
The version constraint should be <=3.6.2 (or ideally <3.7.0), not <=3.6.0. As the plugin works fine with the last 3.6.x version of prettier.

**Update:** Although the plugin works correctly with `prettier@3.6`, it turned out there was a type mismatch which showed up during compilation - I've fixed this as well. 