### PR TITLE
Add Prettier module augmentation for custom options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,14 @@ export const options: Record<keyof MultilineArrayOptions, SupportOption> = getOb
 export const defaultOptions: Partial<RequiredOptions> & Required<MultilineArrayOptions> =
     defaultMultilineArrayOptions;
 
+/*
+ * Augment Prettier's `Options` interface with multiline array options.
+ */
+declare module 'prettier' {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- module augmentation requires extends
+    interface Options extends Partial<MultilineArrayOptions> {}
+}
+
 /** Not actually exported: this is just for type checking purposes. */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const plugin: Plugin = {


### PR DESCRIPTION
## Summary

- Augments Prettier's `Options` interface with `MultilineArrayOptions` so consumers get autocomplete and type safety in TypeScript configs without a separate type import

Closes #67

## Test plan

- [x] Compile, test, format, and lint all pass locally
- [x] Verified `dist/index.d.ts` includes the `declare module 'prettier'` block