### PR TITLE
Make `prettier-multiline-arrays-next-line-` Target Next Line's AST Node's First Array-Like Descendant

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ This plugin provides two new options for your Prettier config:
 
 ## Comment overrides
 
--   Add a comment starting with `prettier-multiline-arrays-next-threshold:` followed by a single number to control `multilineArraysWrapThreshold` for an array on the next line.
--   Add a comment starting with `prettier-multiline-arrays-next-line-pattern:` followed by a pattern of numbers to control `multilineArraysLinePattern` for an array on the next line.
+-   Add a comment starting with `prettier-multiline-arrays-next-threshold:` followed by a single number to control `multilineArraysWrapThreshold` for the next array-like expression.
+-   Add a comment starting with `prettier-multiline-arrays-next-line-pattern:` followed by a pattern of numbers to control `multilineArraysLinePattern` for the next array-like expression.
+
+`next` comments also target the first array-like expression inside a wrapper that starts on the following line, such as a constructor or function call with the array argument on a later line.
 
 To set a comment override for all arrays in a file following the comment, change `next` to `set`. Like so:
 

--- a/src/printer/comment-triggers.ts
+++ b/src/printer/comment-triggers.ts
@@ -12,6 +12,7 @@ import {
     untilSetWrapThresholdCommentRegExp,
 } from '../options.js';
 import {extractComments} from './comments.js';
+import {isArrayLikeNode} from './supported-node-types.js';
 
 type LineNumberDetails<T> = {[lineNumber: number]: T};
 export type LineCounts = LineNumberDetails<number[]>;
@@ -32,6 +33,23 @@ type InternalCommentTriggers = CommentTriggers & {
 };
 
 const mappedCommentTriggers = new WeakMap<Node, CommentTriggers>();
+const ignoredAstChildKeys = [
+    'comments',
+    'leadingComments',
+    'loc',
+    'range',
+    'raw',
+    'tokens',
+    'trailingComments',
+    'value',
+];
+const descendantBoundaryTypes = [
+    'ArrowFunctionExpression',
+    'ClassDeclaration',
+    'ClassExpression',
+    'FunctionDeclaration',
+    'FunctionExpression',
+];
 
 export function getCommentTriggers(key: Node, debug: boolean): CommentTriggers {
     const alreadyExisting = mappedCommentTriggers.get(key);
@@ -105,6 +123,7 @@ function setCommentTriggers(rootNode: Node, debug: boolean): CommentTriggers {
     internalCommentTriggers.resets.sort();
 
     setResets(internalCommentTriggers);
+    mapNextCommentTriggers(rootNode, internalCommentTriggers);
 
     const commentTriggers = {
         ...internalCommentTriggers,
@@ -114,6 +133,113 @@ function setCommentTriggers(rootNode: Node, debug: boolean): CommentTriggers {
     // save to a map so we don't have to recalculate these every time
     mappedCommentTriggers.set(rootNode, commentTriggers);
     return commentTriggers;
+}
+
+function mapNextCommentTriggers(
+    rootNode: Node,
+    internalCommentTriggers: InternalCommentTriggers,
+): void {
+    internalCommentTriggers.nextLineCounts = mapNextLineTriggers(
+        rootNode,
+        internalCommentTriggers.nextLineCounts,
+    );
+    internalCommentTriggers.nextWrapThresholds = mapNextLineTriggers(
+        rootNode,
+        internalCommentTriggers.nextWrapThresholds,
+    );
+}
+
+function mapNextLineTriggers<T>(
+    rootNode: Node,
+    triggers: LineNumberDetails<T>,
+): LineNumberDetails<T> {
+    return getObjectTypedKeys(triggers).reduce((mappedTriggers, triggerLineNumber) => {
+        const trigger = triggers[triggerLineNumber];
+        const triggerLineNumberText = String(triggerLineNumber);
+        const targetLineNumber = findArrayLikeTargetLine(
+            rootNode,
+            Number(triggerLineNumberText) + 1,
+        );
+
+        if (targetLineNumber != undefined && trigger != undefined) {
+            mappedTriggers[targetLineNumber] = trigger;
+        }
+
+        return mappedTriggers;
+    }, {} as LineNumberDetails<T>);
+}
+
+function findArrayLikeTargetLine(rootNode: Node, nextLineNumber: number): number | undefined {
+    return findAstNodesStartingOnLine(rootNode, nextLineNumber)
+        .flatMap((node) => findArrayLikeDescendantLines(node))
+        .sort((a, b) => a - b)[0];
+}
+
+function findAstNodesStartingOnLine(rootNode: Node, lineNumber: number): Node[] {
+    const matchingNodes: Node[] = [];
+    walkAstNodes(rootNode, (node) => {
+        if (node.loc?.start.line === lineNumber) {
+            matchingNodes.push(node);
+        }
+    });
+
+    return matchingNodes;
+}
+
+function findArrayLikeDescendantLines(rootNode: Node): number[] {
+    const lines: number[] = [];
+    walkAstNodes(rootNode, (node) => {
+        if (descendantBoundaryTypes.includes(node.type)) {
+            return false;
+        }
+
+        if (isArrayLikeNode(node) && node.loc) {
+            lines.push(node.loc.start.line);
+        }
+
+        return true;
+    });
+
+    return lines;
+}
+
+function walkAstNodes(
+    rootNode: Node,
+    callback: (node: Node, isRootNode: boolean) => boolean | void,
+): void {
+    const seenNodes = new WeakSet<object>();
+
+    function walk(input: unknown, isRootNode: boolean): void {
+        if (!input || typeof input !== 'object' || seenNodes.has(input)) {
+            return;
+        }
+
+        seenNodes.add(input);
+
+        if (Array.isArray(input)) {
+            input.forEach((entry) => walk(entry, false));
+            return;
+        }
+
+        const maybeNode = input as Partial<Node>;
+
+        if (typeof maybeNode.type !== 'string') {
+            return;
+        }
+
+        const shouldWalkChildren = callback(maybeNode as Node, isRootNode);
+        if (shouldWalkChildren === false) {
+            return;
+        }
+
+        Object.keys(input).forEach((nodeKey) => {
+            if (!ignoredAstChildKeys.includes(nodeKey)) {
+                walk((input as Record<string, unknown>)[nodeKey], false);
+            }
+        });
+    }
+
+    walk(rootNode, true);
 }
 
 function setResets(internalCommentTriggers: InternalCommentTriggers): void {

--- a/src/printer/insert-new-lines.ts
+++ b/src/printer/insert-new-lines.ts
@@ -564,7 +564,6 @@ export function printWithMultilineArrays(
             throw new Error(`Could not find location of node ${node.type}`);
         }
         const currentLineNumber = node.loc.start.line;
-        const lastLine = currentLineNumber - 1;
         const commentTriggers = getCommentTriggers(rootNode, debug);
 
         const originalText: string = inputOptions.originalText;
@@ -607,7 +606,7 @@ export function printWithMultilineArrays(
         );
 
         const lineCounts: number[] =
-            commentTriggers.nextLineCounts[lastLine] ??
+            commentTriggers.nextLineCounts[currentLineNumber] ??
             relevantSetLineCount ??
             parseNextLineCounts(inputOptions.multilineArraysLinePattern, false, debug);
 
@@ -617,15 +616,15 @@ export function printWithMultilineArrays(
         );
 
         const wrapThreshold: number =
-            commentTriggers.nextWrapThresholds[lastLine] ??
+            commentTriggers.nextWrapThresholds[currentLineNumber] ??
             relevantSetWrapCommentThreshold ??
             (inputOptions.multilineArraysWrapThreshold < 0
                 ? Infinity
                 : inputOptions.multilineArraysWrapThreshold);
 
         const includesCommentTrigger: boolean =
-            (commentTriggers.nextWrapThresholds[lastLine] ?? relevantSetWrapCommentThreshold) !=
-                undefined || !!lineCounts.length;
+            (commentTriggers.nextWrapThresholds[currentLineNumber] ??
+                relevantSetWrapCommentThreshold) != undefined || !!lineCounts.length;
 
         if (debug) {
             console.info(`======= Starting call to ${insertLinesIntoArray.name}: =======`);

--- a/src/test/typescript-tests.mock.ts
+++ b/src/test/typescript-tests.mock.ts
@@ -459,6 +459,69 @@ export const typescriptTests: MultilineArrayTest[] = [
         `,
     },
     {
+        it: 'line pattern comment targets array inside next new expression GitHub Issue #73',
+        code: `
+            // ${nextLinePatternComment} 2
+            new Set(
+                [
+                    1,
+                    2,
+                    3,
+                    4,
+                ],
+            );
+        `,
+        expect: `
+            // ${nextLinePatternComment} 2
+            new Set([
+                1, 2,
+                3, 4,
+            ]);
+        `,
+    },
+    {
+        it: 'line pattern comment targets outer array before nested call arrays GitHub Issue #73',
+        code: `
+            // ${nextLinePatternComment} 4
+            [
+                fn([1,2]),
+                2,
+                3,
+                4,
+            ]
+        `,
+        expect: `
+            // ${nextLinePatternComment} 4
+            [
+                fn([1, 2]), 2, 3, 4,
+            ];
+        `,
+    },
+    {
+        it: 'threshold comment targets array inside next call expression GitHub Issue #73',
+        code: `
+            // ${nextWrapThresholdComment} 4
+            fn(
+                [
+                    1,
+                    2,
+                ],
+            );
+        `,
+        expect: `
+            // ${nextWrapThresholdComment} 4
+            fn([1, 2]);
+        `,
+    },
+    {
+        it: 'next line comments do not skip over non-array statements',
+        code: `
+            // ${nextLinePatternComment} 2
+            doThing();
+            const laterArray = [0, 1, 2, 3];
+        `,
+    },
+    {
         it: 'set line pattern comment should carry through',
         code: `
             // ${setLinePatternComment} 2


### PR DESCRIPTION
Resolves #73.